### PR TITLE
Add support for the pagefind highlight script

### DIFF
--- a/.changeset/proud-peaches-cheat.md
+++ b/.changeset/proud-peaches-cheat.md
@@ -1,0 +1,8 @@
+---
+"vite-plugin-pagefind": patch
+---
+
+Add support for the pagefind highlight script,
+as well as a new configuration option to support
+having the pagefind bundle placed in other places
+other than the default `/pagefind/pagefind.js`.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ The command to build and index the project.
 
 _default_: 'npm run build'
 
+### pagefind_url
+
+The URL you use to import the pagefind script on your site. For example, if you use `/pagefind/pagefind.js`, the `pagefind_url` is `pagefind`. If you use `/search/static/pagefind/pagefind.js`, the `pagefind_url` is `search/static/pagefind`
+
+_default_: 'pagefind'
+
 ### dev_strategy
 
 The indexing strategy used during development:
@@ -98,8 +104,8 @@ const pagefind: Pagefind = await import("/pagefind/pagefind.js");
 
 ## Pagefind
 
-For further questions regarding Pagefind itself you can refer to [the offical docs](https://pagefind.app/).
+For further questions regarding Pagefind itself you can refer to [the official docs](https://pagefind.app/).
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE.txt](LICENSE.txt) file for details.

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ The command to build and index the project.
 
 _default_: 'npm run build'
 
-### pagefind_url
+### pagefind_dir
 
-The URL you use to import the pagefind script on your site. For example, if you use `/pagefind/pagefind.js`, the `pagefind_url` is `pagefind`. If you use `/search/static/pagefind/pagefind.js`, the `pagefind_url` is `search/static/pagefind`
+The URL directory you use to import the pagefind script on your site. For example, if you use `/pagefind/pagefind.js`, the `pagefind_dir` is `pagefind`. If you use `/search/static/pagefind/pagefind.js`, the `pagefind_dir` is `search/static/pagefind`.
 
 _default_: 'pagefind'
 

--- a/package.json
+++ b/package.json
@@ -12,17 +12,11 @@
 		"url": "https://github.com/Hugos68/vite-plugin-pagefind"
 	},
 	"homepage": "https://github.com/Hugos68/vite-plugin-pagefind#vite-plugin-pagefind",
-	"keywords": [
-		"vite",
-		"vite-plugin",
-		"pagefind"
-	],
+	"keywords": ["vite", "vite-plugin", "pagefind"],
 	"publishConfig": {
 		"access": "public"
 	},
-	"files": [
-		"dist"
-	],
+	"files": ["dist"],
 	"main": "./dist/plugins/pagefind.js",
 	"exports": {
 		".": {

--- a/src/internal/config.js
+++ b/src/internal/config.js
@@ -8,7 +8,7 @@ const PagefindConfigSchema = v.object({
 		v.object({
 			assets_dir: v.optional(v.string(), "public"),
 			build_command: v.optional(v.string(), "npm run build"),
-			pagefind_url: v.optional(v.string(), "pagefind"),
+			pagefind_dir: v.optional(v.string(), "pagefind"),
 			dev_strategy: v.optional(v.picklist(["eager", "lazy"]), "lazy"),
 		}),
 		{},
@@ -27,8 +27,8 @@ export async function get_pagefind_config(cwd) {
 	);
 	const pagefind_parsed = JSON.parse(pagefind_raw);
 	const config = v.parse(PagefindConfigSchema, pagefind_parsed);
-	const pagefind_url = config.vite_plugin_pagefind.pagefind_url;
-	config.vite_plugin_pagefind.pagefind_url = pagefind_url.replace(
+	const pagefind_dir = config.vite_plugin_pagefind.pagefind_dir;
+	config.vite_plugin_pagefind.pagefind_dir = pagefind_dir.replace(
 		/^\/+|\/+$/g,
 		"",
 	);

--- a/src/internal/config.js
+++ b/src/internal/config.js
@@ -27,6 +27,10 @@ export async function get_pagefind_config(cwd) {
 	);
 	const pagefind_parsed = JSON.parse(pagefind_raw);
 	const config = v.parse(PagefindConfigSchema, pagefind_parsed);
-	config.pagefind_url = config.pagefind_url.replace(/^\/+|\/+$/g, "");
+	const pagefind_url = config.vite_plugin_pagefind.pagefind_url;
+	config.vite_plugin_pagefind.pagefind_url = pagefind_url.replace(
+		/^\/+|\/+$/g,
+		"",
+	);
 	return config;
 }

--- a/src/internal/config.js
+++ b/src/internal/config.js
@@ -8,6 +8,7 @@ const PagefindConfigSchema = v.object({
 		v.object({
 			assets_dir: v.optional(v.string(), "public"),
 			build_command: v.optional(v.string(), "npm run build"),
+			pagefind_url: v.optional(v.string(), "pagefind"),
 			dev_strategy: v.optional(v.picklist(["eager", "lazy"]), "lazy"),
 		}),
 		{},
@@ -25,5 +26,7 @@ export async function get_pagefind_config(cwd) {
 		"utf-8",
 	);
 	const pagefind_parsed = JSON.parse(pagefind_raw);
-	return v.parse(PagefindConfigSchema, pagefind_parsed);
+	const config = v.parse(PagefindConfigSchema, pagefind_parsed);
+	config.pagefind_url = config.pagefind_url.replace(/^\/+|\/+$/g, "");
+	return config;
 }

--- a/src/plugins/pagefind-build.js
+++ b/src/plugins/pagefind-build.js
@@ -12,13 +12,13 @@ export default function build() {
 		async config() {
 			const cwd = process.cwd();
 			const pagefind_config = await get_pagefind_config(cwd);
-			const pagefind_url = pagefind_config.vite_plugin_pagefind.pagefind_url;
+			const pagefind_dir = pagefind_config.vite_plugin_pagefind.pagefind_dir;
 			return {
 				build: {
 					rollupOptions: {
 						external: [
-							`/${pagefind_url}/pagefind.js`,
-							`/${pagefind_url}/pagefind-highlight.js`,
+							`/${pagefind_dir}/pagefind.js`,
+							`/${pagefind_dir}/pagefind-highlight.js`,
 						],
 					},
 				},

--- a/src/plugins/pagefind-build.js
+++ b/src/plugins/pagefind-build.js
@@ -1,3 +1,4 @@
+import { get_pagefind_config } from "../internal/config.js";
 import { PACKAGE_NAME } from "../internal/constants.js";
 
 /**
@@ -8,11 +9,14 @@ export default function build() {
 	return {
 		name: `${PACKAGE_NAME}-build`,
 		apply: "build",
-		config() {
+		async config() {
+			const cwd = process.cwd();
+			const pagefind_config = await get_pagefind_config(cwd);
+			const pagefind_url = pagefind_config.pagefind_url;
 			return {
 				build: {
 					rollupOptions: {
-						external: "/pagefind/pagefind.js",
+						external: [`/${pagefind_url}/pagefind.js`, `/${pagefind_url}/pagefind-highlight.js`],
 					},
 				},
 			};

--- a/src/plugins/pagefind-build.js
+++ b/src/plugins/pagefind-build.js
@@ -16,7 +16,10 @@ export default function build() {
 			return {
 				build: {
 					rollupOptions: {
-						external: [`/${pagefind_url}/pagefind.js`, `/${pagefind_url}/pagefind-highlight.js`],
+						external: [
+							`/${pagefind_url}/pagefind.js`,
+							`/${pagefind_url}/pagefind-highlight.js`,
+						],
 					},
 				},
 			};

--- a/src/plugins/pagefind-build.js
+++ b/src/plugins/pagefind-build.js
@@ -12,7 +12,7 @@ export default function build() {
 		async config() {
 			const cwd = process.cwd();
 			const pagefind_config = await get_pagefind_config(cwd);
-			const pagefind_url = pagefind_config.pagefind_url;
+			const pagefind_url = pagefind_config.vite_plugin_pagefind.pagefind_url;
 			return {
 				build: {
 					rollupOptions: {

--- a/src/plugins/pagefind-dev.js
+++ b/src/plugins/pagefind-dev.js
@@ -20,14 +20,14 @@ export default function dev() {
 		async config() {
 			const cwd = process.cwd();
 			const pagefind_config = await get_pagefind_config(cwd);
-			const pagefind_url = pagefind_config.vite_plugin_pagefind.pagefind_url;
+			const pagefind_dir = pagefind_config.vite_plugin_pagefind.pagefind_dir;
 			return {
 				assetsInclude: ["**/pagefind.js", "**/pagefind-highlight.js"],
 				build: {
 					rollupOptions: {
 						external: [
-							`/${pagefind_url}/pagefind.js`,
-							`/${pagefind_url}/pagefind-highlight.js`,
+							`/${pagefind_dir}/pagefind.js`,
+							`/${pagefind_dir}/pagefind-highlight.js`,
 						],
 					},
 				},

--- a/src/plugins/pagefind-dev.js
+++ b/src/plugins/pagefind-dev.js
@@ -25,7 +25,10 @@ export default function dev() {
 				assetsInclude: ["**/pagefind.js", "**/pagefind-highlight.js"],
 				build: {
 					rollupOptions: {
-						external: [`/${pagefind_url}/pagefind.js`, `/${pagefind_url}/pagefind-highlight.js`],
+						external: [
+							`/${pagefind_url}/pagefind.js`,
+							`/${pagefind_url}/pagefind-highlight.js`,
+						],
 					},
 				},
 			};

--- a/src/plugins/pagefind-dev.js
+++ b/src/plugins/pagefind-dev.js
@@ -20,7 +20,7 @@ export default function dev() {
 		async config() {
 			const cwd = process.cwd();
 			const pagefind_config = await get_pagefind_config(cwd);
-			const pagefind_url = pagefind_config.pagefind_url;
+			const pagefind_url = pagefind_config.vite_plugin_pagefind.pagefind_url;
 			return {
 				assetsInclude: ["**/pagefind.js", "**/pagefind-highlight.js"],
 				build: {

--- a/src/plugins/pagefind-dev.js
+++ b/src/plugins/pagefind-dev.js
@@ -18,11 +18,14 @@ export default function dev() {
 		apply: "serve",
 		enforce: "post",
 		async config() {
+			const cwd = process.cwd();
+			const pagefind_config = await get_pagefind_config(cwd);
+			const pagefind_url = pagefind_config.pagefind_url;
 			return {
-				assetsInclude: "**/pagefind.js",
+				assetsInclude: ["**/pagefind.js", "**/pagefind-highlight.js"],
 				build: {
 					rollupOptions: {
-						external: "/pagefind/pagefind.js",
+						external: [`/${pagefind_url}/pagefind.js`, `/${pagefind_url}/pagefind-highlight.js`],
 					},
 				},
 			};


### PR DESCRIPTION
Also added the ability to customise the URL that pagefind is being imported from, instead of relying on the default import of `/pagefind/pagefind.js`.

Updated the documentation to reflect this additional configuration option.

Also fixed a typo in the README, `offical` -> `official`.