### PR TITLE
Updated the dependencies to the latest versions

### DIFF
--- a/.changeset/rare-flies-rule.md
+++ b/.changeset/rare-flies-rule.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-pagefind": patch
+---
+
+Update dependencies to the latest versions and fixed the resolved config type not matching Vite's.

--- a/biome.json
+++ b/biome.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
 	"files": {
-		"ignore": ["dist", "node_modules"]
+		"includes": ["**", "!**/dist", "!**/node_modules"]
 	}
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 	},
 	"dependencies": {
 		"colorette": "^2.0.20",
-		"package-manager-detector": "^1.3.0"
+		"package-manager-detector": "^0.2.11"
 	},
 	"peerDependencies": {
 		"vite": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
 		"package-manager-detector": "^0.2.11"
 	},
 	"peerDependencies": {
-		"vite": "^6.0.0"
+		"vite": "^7.0.0"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.1.1",
+		"@biomejs/biome": "^2.1.1",
 		"@changesets/cli": "^2.29.5",
 		"@types/node": "^24.0.13",
 		"typescript": "^5.8.3",

--- a/package.json
+++ b/package.json
@@ -32,17 +32,17 @@
 	},
 	"dependencies": {
 		"colorette": "^2.0.20",
-		"package-manager-detector": "^0.2.8"
+		"package-manager-detector": "^1.3.0"
 	},
 	"peerDependencies": {
 		"vite": "^6.0.0"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "1.9.4",
-		"@changesets/cli": "^2.27.12",
-		"@types/node": "^22.10.10",
-		"typescript": "^5.7.3",
-		"unbuild": "^3.3.1"
+		"@biomejs/biome": "2.1.1",
+		"@changesets/cli": "^2.29.5",
+		"@types/node": "^24.0.13",
+		"typescript": "^5.8.3",
+		"unbuild": "^3.5.0"
 	},
 	"type": "module"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ function log(message: string) {
 	console.log(`${blue("[vite-plugin-pagefind]")} ${message}`);
 }
 
-function pagefind(options: PagefindOptions = {}): Plugin[] {
+function pagefind(options: PagefindOptions = {}): Plugin {
 	return [pagefindBuild(options), pagefindDevelop(options)];
 }
 
@@ -41,7 +41,7 @@ function pagefindBuild(options: PagefindBuildOptions = {}): Plugin {
 				},
 			};
 		},
-	} satisfies Plugin;
+	};
 }
 
 function pagefindDevelop(options: PagefindDevelopOptions = {}): Plugin {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ function log(message: string) {
 	console.log(`${blue("[vite-plugin-pagefind]")} ${message}`);
 }
 
-function pagefind(options: PagefindOptions = {}): Plugin {
+function pagefind(options: PagefindOptions = {}): Plugin[] {
 	return [pagefindBuild(options), pagefindDevelop(options)];
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { cpSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { blue } from "colorette";
 import { detectSync, resolveCommand } from "package-manager-detector";
-import type { Plugin, ResolvedConfig } from "vite";
+import type { Plugin } from "vite";
 
 interface PagefindOptions {
 	outputDirectory?: string;
@@ -20,11 +20,11 @@ function log(message: string) {
 	console.log(`${blue("[vite-plugin-pagefind]")} ${message}`);
 }
 
-function pagefind(options: PagefindOptions = {}) {
-	return [pagefindBuild(options), pagefindDevelop(options)] satisfies Plugin[];
+function pagefind(options: PagefindOptions = {}): Plugin[] {
+	return [pagefindBuild(options), pagefindDevelop(options)];
 }
 
-function pagefindBuild(options: PagefindBuildOptions = {}) {
+function pagefindBuild(options: PagefindBuildOptions = {}): Plugin {
 	const bundleDirectory = options.bundleDirectory ?? "pagefind";
 	return {
 		name: "pagefind-build",
@@ -44,7 +44,7 @@ function pagefindBuild(options: PagefindBuildOptions = {}) {
 	} satisfies Plugin;
 }
 
-function pagefindDevelop(options: PagefindDevelopOptions = {}) {
+function pagefindDevelop(options: PagefindDevelopOptions = {}): Plugin {
 	const outputDirectory = options.outputDirectory ?? "build";
 	const assetsDirectory = options.assetsDirectory ?? "public";
 	const bundleDirectory = options.bundleDirectory ?? "pagefind";
@@ -66,7 +66,7 @@ function pagefindDevelop(options: PagefindDevelopOptions = {}) {
 				},
 			};
 		},
-		configResolved(config: ResolvedConfig) {
+		configResolved(config) {
 			const absoluteOutputDirectory = resolve(config.root, outputDirectory);
 			const absoluteAssetsDirectory = resolve(config.root, assetsDirectory);
 			function build() {
@@ -118,7 +118,7 @@ function pagefindDevelop(options: PagefindDevelopOptions = {}) {
 				}
 			}
 		},
-	} satisfies Plugin;
+	};
 }
 
 export type { PagefindOptions, PagefindBuildOptions, PagefindDevelopOptions };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { cpSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { blue } from "colorette";
 import { detectSync, resolveCommand } from "package-manager-detector";
-import type { Plugin } from "vite";
+import type { Plugin, ResolvedConfig } from "vite";
 
 interface PagefindOptions {
 	outputDirectory?: string;
@@ -66,7 +66,7 @@ function pagefindDevelop(options: PagefindDevelopOptions = {}) {
 				},
 			};
 		},
-		configResolved(config) {
+		configResolved(config: ResolvedConfig) {
 			const absoluteOutputDirectory = resolve(config.root, outputDirectory);
 			const absoluteAssetsDirectory = resolve(config.root, assetsDirectory);
 			function build() {


### PR DESCRIPTION
Except for `package-manager-detector`, it seems like they removed the sync API in version 1.0 and up.

Fixed the resolved config type not matching Vite's.

Fixes #70.