### PR TITLE
fix: add null to search term type

### DIFF
--- a/.changeset/eighty-houses-say.md
+++ b/.changeset/eighty-houses-say.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-pagefind": patch
+---
+
+Add null to search term type

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,7 +98,7 @@ interface Pagefind {
 	options: (options: PagefindIndexOptions) => Promise<void>;
 	preload: (term: string, options?: PagefindIndexOptions) => Promise<void>;
 	search: (
-		term: string,
+		term: string | null,
 		options?: PagefindSearchOptions,
 	) => Promise<PagefindSearchResults>;
 }


### PR DESCRIPTION
Updated the search API type to allow null for the search term.

According to the official documentation(https://pagefind.app/docs/js-api-filtering/#filtering-as-a-standalone-action),
null is supported as a valid search term.